### PR TITLE
feat: Initial Godot project setup for AvatarStream

### DIFF
--- a/AvatarStream/export_presets.cfg
+++ b/AvatarStream/export_presets.cfg
@@ -1,0 +1,10 @@
+[preset.0]
+name="macOS"
+platform="Mac OS X"
+runnable=true
+export_path="build/macos/AvatarStream.dmg"
+binary_format="universal"
+architecture="arm64"
+application/short_version="1.0"
+application/version="1.0.0"
+os/min_os_version="14.0"

--- a/AvatarStream/project.godot
+++ b/AvatarStream/project.godot
@@ -1,0 +1,17 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters might change in the future.
+
+config_version=5
+
+[application]
+
+config/name="AvatarStream"
+config/features=PackedStringArray("4.3", "3D")
+config/icon="res://icon.svg"
+run/main_scene="res://scenes/MainMenu.tscn"
+
+[rendering]
+
+renderer/rendering_method="forward_plus"
+textures/vram_compression/import_etc2_astc=true

--- a/AvatarStream/scenes/AvatarNode.tscn
+++ b/AvatarStream/scenes/AvatarNode.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=2 format=3 uid="uid://dix2yabg0f7sm"]
+
+[sub_resource type="BoxMesh" id="BoxMesh_vvt2v"]
+
+[node name="AvatarNode" type="Node3D"]
+
+[node name="Skeleton3D" type="Skeleton3D" parent="."]
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_vvt2v")

--- a/AvatarStream/scenes/MainMenu.tscn
+++ b/AvatarStream/scenes/MainMenu.tscn
@@ -1,0 +1,3 @@
+[gd_scene format=3 uid="uid://cyaeyy6224qf1"]
+
+[node name="MainMenu" type="CanvasLayer"]

--- a/AvatarStream/scenes/MainScene.tscn
+++ b/AvatarStream/scenes/MainScene.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=4 format=3 uid="uid://b6ywm2nwa7fkb"]
+
+[ext_resource type="PackedScene" uid="uid://dix2yabg0f7sm" path="res://scenes/AvatarNode.tscn" id="1_xqrw7"]
+[ext_resource type="Script" path="res://scripts/GameManager.gd" id="2_wg2w7"]
+[ext_resource type="Script" path="res://scripts/AvatarGenerator.gd" id="3_6d3d0"]
+
+[node name="MainScene" type="Node3D"]
+
+[node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 5, 5)
+
+[node name="Camera3D" type="Camera3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 5)
+
+[node name="AvatarPlaceholder" parent="." instance=ExtResource("1_xqrw7")]
+
+[node name="GameManager" type="Node" parent="."]
+script = ExtResource("2_wg2w7")
+
+[node name="AvatarGenerator" type="Node" parent="."]
+script = ExtResource("3_6d3d0")

--- a/AvatarStream/scripts/AvatarGenerator.gd
+++ b/AvatarStream/scripts/AvatarGenerator.gd
@@ -1,0 +1,16 @@
+extends Node
+
+func generate_avatar():
+	var command = "python3.12"
+	var args = ["-c", "import torch; import cv2; print('hello from python')"] # a simple python script
+	var output = []
+	var exit_code = OS.execute(command, args, output)
+	if exit_code == 0:
+		print("Python script executed successfully")
+		print("Output: ", output[0])
+	else:
+		print("Error executing python script")
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	generate_avatar()

--- a/AvatarStream/scripts/GameManager.gd
+++ b/AvatarStream/scripts/GameManager.gd
@@ -1,0 +1,9 @@
+extends Node
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass


### PR DESCRIPTION
This commit contains the initial setup for the AvatarStream Godot project.

It includes:
- A new Godot 4.3+ project.
- The directory structure for scenes, scripts, assets, and addons.
- Initial scenes: MainMenu.tscn, AvatarNode.tscn, and MainScene.tscn.
- `AvatarNode.tscn` includes a placeholder mesh.
- Initial scripts: GameManager.gd and AvatarGenerator.gd.
- Configuration for macOS export (Apple Silicon Universal Binary, target 14+).
- The main scene is set to MainMenu.tscn.