### PR TITLE
feat: Add AI avatar generation pipeline

### DIFF
--- a/AvatarStream/scenes/AvatarGen.tscn
+++ b/AvatarStream/scenes/AvatarGen.tscn
@@ -1,0 +1,62 @@
+[gd_scene load_steps=2 format=3 uid="uid://cgrv8ggmab22l"]
+
+[ext_resource type="Script" path="res://scripts/AvatarGen.gd" id="1_abcde"]
+
+[node name="AvatarGen" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_abcde")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -100.0
+offset_top = -100.0
+offset_right = 100.0
+offset_bottom = 100.0
+grow_horizontal = 2
+grow_vertical = 2
+spacing = 10
+
+[node name="SelectImageButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+text = "Select Image"
+
+[node name="WebcamButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+text = "Use Webcam"
+
+[node name="ProgressBar" type="ProgressBar" parent="VBoxContainer"]
+layout_mode = 2
+value = 0
+show_percentage = true
+
+[node name="StatusLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Select an image to start."
+horizontal_alignment = 1
+
+[node name="BackButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+text = "Back to Main Menu"
+
+[node name="FileDialog" type="FileDialog" parent="."]
+title = "Open a File"
+size = Vector2i(500, 400)
+ok_button_text = "Open"
+file_mode = 0
+access = 2
+filters = PackedStringArray("*.png, *.jpg ; Image Files")
+
+[connection signal="pressed" from="VBoxContainer/SelectImageButton" to="." method="_on_select_image_button_pressed"]
+[connection signal="pressed" from="VBoxContainer/WebcamButton" to="." method="_on_webcam_button_pressed"]
+[connection signal="pressed" from="VBoxContainer/BackButton" to="." method="_on_back_button_pressed"]
+[connection signal="file_selected" from="FileDialog" to="." method="_on_file_dialog_file_selected"]

--- a/AvatarStream/scenes/MainMenu.tscn
+++ b/AvatarStream/scenes/MainMenu.tscn
@@ -11,7 +11,7 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_f5gde")
 
-[node name="LoadAvatarButton" type="Button" parent="."]
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
@@ -19,11 +19,21 @@ anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
 offset_left = -100.0
-offset_top = -25.0
+offset_top = -50.0
 offset_right = 100.0
-offset_bottom = 25.0
+offset_bottom = 50.0
 grow_horizontal = 2
 grow_vertical = 2
-text = "Load Avatar"
+spacing = 10
 
-[connection signal="pressed" from="LoadAvatarButton" to="." method="_on_LoadAvatar_pressed"]
+[node name="LoadAvatarButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 4
+text = "Load Default Avatar"
+
+[node name="GenerateAvatarButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+text = "Generate New Avatar"
+
+[connection signal="pressed" from="VBoxContainer/LoadAvatarButton" to="." method="_on_LoadAvatar_pressed"]
+[connection signal="pressed" from="VBoxContainer/GenerateAvatarButton" to="." method="_on_GenerateAvatar_pressed"]

--- a/AvatarStream/scenes/MainScene.tscn
+++ b/AvatarStream/scenes/MainScene.tscn
@@ -1,8 +1,11 @@
-[gd_scene load_steps=2 format=3 uid="uid://b6ywm2nwa7fkb"]
+[gd_scene load_steps=3 format=3 uid="uid://b6ywm2nwa7fkb"]
 
-[ext_resource type="PackedScene" uid="uid://dix2yabg0f7sm" path="res://scenes/AvatarNode.tscn" id="1_xqrw7"]
+[ext_resource type="Script" path="res://scripts/MainScene.gd" id="1_abcde"]
+[ext_resource type="PackedScene" uid="uid://dix2yabg0f7sm" path="res://scenes/AvatarNode.tscn" id="2_xqrw7"]
 
-[node name="MainScene" type="Node3D"]
+[node name="MainScene" type="Node3D" node_paths=PackedStringArray("avatar_placeholder")]
+script = ExtResource("1_abcde")
+avatar_placeholder = NodePath("AvatarPlaceholder")
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 5, 5)
@@ -10,4 +13,4 @@ transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 
 [node name="Camera3D" type="Camera3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 5)
 
-[node name="AvatarPlaceholder" parent="." instance=ExtResource("1_xqrw7")]
+[node name="AvatarPlaceholder" parent="." instance=ExtResource("2_xqrw7")]

--- a/AvatarStream/scripts/AvatarGen.gd
+++ b/AvatarStream/scripts/AvatarGen.gd
@@ -1,0 +1,50 @@
+extends Control
+
+@onready var progress_bar = $VBoxContainer/ProgressBar
+@onready var status_label = $VBoxContainer/StatusLabel
+@onready var file_dialog = $FileDialog
+@onready var select_image_button = $VBoxContainer/SelectImageButton
+@onready var webcam_button = $VBoxContainer/WebcamButton
+@onready var back_button = $VBoxContainer/BackButton
+
+func _ready():
+	# Connect to the AvatarGenerator singleton
+	AvatarGenerator.generation_started.connect(_on_generation_started)
+	AvatarGenerator.generation_progress.connect(_on_generation_progress)
+	AvatarGenerator.generation_finished.connect(_on_generation_finished)
+
+func _on_select_image_button_pressed():
+	file_dialog.popup_centered()
+
+func _on_webcam_button_pressed():
+	status_label.text = "Webcam not implemented yet."
+	# Placeholder for webcam logic
+
+func _on_back_button_pressed():
+	get_tree().change_scene_to_file("res://scenes/MainMenu.tscn")
+
+func _on_file_dialog_file_selected(path: String):
+	status_label.text = "Starting generation..."
+	AvatarGenerator.generate_avatar(path)
+
+func _on_generation_started():
+	progress_bar.value = 0
+	progress_bar.visible = true
+	status_label.text = "Generation in progress..."
+	select_image_button.disabled = true
+	webcam_button.disabled = true
+	back_button.disabled = true
+
+func _on_generation_progress(value: float):
+	progress_bar.value = value
+	status_label.text = "Generation in progress... " + str(value) + "%"
+
+func _on_generation_finished(path: String):
+	status_label.text = "Generation complete!"
+	select_image_button.disabled = false
+	webcam_button.disabled = false
+	back_button.disabled = false
+
+	# Store the path and switch to the main scene
+	GameManager.generated_avatar_path = path
+	get_tree().change_scene_to_file("res://scenes/MainScene.tscn")

--- a/AvatarStream/scripts/AvatarGenerator.gd
+++ b/AvatarStream/scripts/AvatarGenerator.gd
@@ -1,7 +1,69 @@
 extends Node
 
+# Signals for generation progress
+signal generation_started
+signal generation_progress(value)
+signal generation_finished(path)
+
 var skeleton: Skeleton3D
 var pose_timer: Timer
+
+# Variables for async process
+var generation_pid = 0
+var progress_file_path = "user://progress.txt"
+var output_gltf_path = ""
+
+func generate_avatar(image_path: String):
+	emit_signal("generation_started")
+
+	# Define paths
+	var python_script_path = "res://scripts/python/generate_avatar.py"
+	# Create a unique filename for the output gltf
+	var timestamp = Time.get_unix_time_from_system()
+	output_gltf_path = "res://assets/avatars/avatar_" + str(timestamp) + ".gltf"
+
+	# Prepare arguments for the script
+	var args = [
+		ProjectSettings.globalize_path(image_path),
+		ProjectSettings.globalize_path(output_gltf_path),
+		ProjectSettings.globalize_path(progress_file_path)
+	]
+
+	# Execute the python script
+	# Note: This assumes 'python' is in the system's PATH.
+	# For better portability, one might specify the full path to the python executable.
+	generation_pid = OS.create_process("python", [ProjectSettings.globalize_path(python_script_path)] + args)
+
+	if generation_pid == -1:
+		print("Error: Failed to start the generation process.")
+		emit_signal("generation_finished", "")
+
+
+func _process(delta):
+	if generation_pid != 0:
+		if OS.is_process_running(generation_pid):
+			# Process is running, check for progress
+			if FileAccess.file_exists(progress_file_path):
+				var file = FileAccess.open(progress_file_path, FileAccess.READ)
+				var progress_text = file.get_as_text()
+				file.close()
+				if progress_text.is_valid_float():
+					emit_signal("generation_progress", float(progress_text))
+		else:
+			# Process finished
+			var exit_code = OS.get_process_exit_code(generation_pid)
+			generation_pid = 0
+
+			if exit_code == 0 and FileAccess.file_exists(output_gltf_path):
+				emit_signal("generation_finished", output_gltf_path)
+			else:
+				print("Error: Generation script failed with exit code: " + str(exit_code))
+				emit_signal("generation_finished", "")
+
+			# Clean up progress file
+			if FileAccess.file_exists(progress_file_path):
+				DirAccess.remove_absolute(ProjectSettings.globalize_path(progress_file_path))
+
 
 func register_skeleton(target_skeleton: Skeleton3D):
 	skeleton = target_skeleton

--- a/AvatarStream/scripts/GameManager.gd
+++ b/AvatarStream/scripts/GameManager.gd
@@ -1,7 +1,14 @@
 extends Node
 
+var generated_avatar_path: String = ""
+
 func _on_LoadAvatar_pressed():
+	# Ensure we load the default avatar if no new one has been generated
+	generated_avatar_path = ""
 	get_tree().change_scene_to_file("res://scenes/MainScene.tscn")
+
+func _on_GenerateAvatar_pressed():
+	get_tree().change_scene_to_file("res://scenes/AvatarGen.tscn")
 
 func _ready():
 	pass

--- a/AvatarStream/scripts/MainScene.gd
+++ b/AvatarStream/scripts/MainScene.gd
@@ -1,0 +1,18 @@
+extends Node3D
+
+@onready var avatar_placeholder = $AvatarPlaceholder
+
+func _ready():
+	if GameManager.generated_avatar_path != "":
+		# A new avatar has been generated, so load it
+		var new_avatar_scene = load(GameManager.generated_avatar_path)
+		if new_avatar_scene:
+			var new_avatar_instance = new_avatar_scene.instantiate()
+			# Replace the placeholder with the new avatar
+			avatar_placeholder.replace_by(new_avatar_instance)
+			# The old placeholder is freed, so we don't need to remove it
+
+			# We can also reset the path so it doesn't load again on scene reload
+			GameManager.generated_avatar_path = ""
+		else:
+			print("Error: Could not load the generated avatar scene from path: " + GameManager.generated_avatar_path)

--- a/AvatarStream/scripts/python/generate_avatar.py
+++ b/AvatarStream/scripts/python/generate_avatar.py
@@ -1,0 +1,84 @@
+import sys
+import time
+import json
+
+def create_dummy_gltf(output_path):
+    # A minimal GLTF file for a single-triangle mesh.
+    # This is simple enough to create without a full library.
+    # In a real scenario, a library like pygltflib would be used.
+    gltf = {
+        "scene": 0,
+        "scenes": [{"nodes": [0]}],
+        "nodes": [{"mesh": 0}],
+        "meshes": [{
+            "primitives": [{
+                "attributes": {
+                    "POSITION": 1
+                },
+                "indices": 0
+            }]
+        }],
+        "buffers": [{
+            "uri": "data:application/octet-stream;base64,AAABAAIAAAAAAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AIA/AAAAAAAAAAAAAIA/AAAAAAAAAA==",
+            "byteLength": 36
+        }],
+        "bufferViews": [{
+            "buffer": 0,
+            "byteOffset": 0,
+            "byteLength": 36,
+            "target": 34962
+        }],
+        "accessors": [{
+            "bufferView": 0,
+            "componentType": 5123,
+            "count": 3,
+            "type": "SCALAR"
+        }, {
+            "bufferView": 0,
+            "byteOffset": 12,
+            "componentType": 5126,
+            "count": 3,
+            "type": "VEC3",
+            "max": [1.0, 1.0, 0.0],
+            "min": [0.0, 0.0, 0.0]
+        }],
+        "asset": {
+            "version": "2.0"
+        }
+    }
+    with open(output_path, 'w') as f:
+        json.dump(gltf, f, indent=4)
+
+def write_progress(progress_file, percentage):
+    with open(progress_file, 'w') as f:
+        f.write(str(percentage))
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4:
+        print("Usage: python generate_avatar.py <input_image> <output_gltf> <progress_file>")
+        sys.exit(1)
+
+    input_image_path = sys.argv[1]
+    output_gltf_path = sys.argv[2]
+    progress_file = sys.argv[3]
+
+    # Simulate a multi-step process
+    steps = {
+        "Preprocessing with OpenCV": 25,
+        "Generating mesh with TripoSR": 75,
+        "Rigging with SMPL-X": 95,
+        "Exporting GLTF": 100
+    }
+
+    write_progress(progress_file, 0)
+    time.sleep(0.5)
+
+    for step, progress in steps.items():
+        # In a real script, you would perform the actual operations here.
+        print(f"Running step: {step}")
+        time.sleep(1) # Simulate work
+        write_progress(progress_file, progress)
+
+    create_dummy_gltf(output_gltf_path)
+    print(f"Dummy GLTF created at {output_gltf_path}")
+    sys.exit(0)

--- a/AvatarStream/scripts/python/requirements.txt
+++ b/AvatarStream/scripts/python/requirements.txt
@@ -1,0 +1,10 @@
+# This file contains the Python dependencies for the avatar generation script.
+# You can install them using: pip install -r requirements.txt
+
+opencv-python
+
+# The following libraries are needed for the full implementation.
+# The exact package names and versions might vary.
+# torch
+# tripo-sr
+# smplx


### PR DESCRIPTION
Integrates a Python-based AI avatar generation pipeline into the Godot application.

This change introduces the following:
- A new 'AvatarGen' scene with UI for file selection and progress display.
- Asynchronous execution of a Python script using OS.create_process to handle the generation.
- A placeholder Python script that simulates a multi-step AI process (OpenCV, TripoSR, SMPL-X) and generates a dummy GLTF model.
- Progress reporting from the Python script back to Godot via a temporary file.
- Logic in the MainScene to load the newly generated avatar and replace the default placeholder.
- Updates to the MainMenu to include a button for accessing the new feature.